### PR TITLE
Bugfixes: Gridelements & jQuery erros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Created by .ignore support plugin (hsz.mobi)
+.idea

--- a/Configuration/TypoScript/sectionBuilder.ts
+++ b/Configuration/TypoScript/sectionBuilder.ts
@@ -24,7 +24,7 @@ plugin.tx_tgmreveal_reveal {
 						table = tt_content
 						select {
 							pidInList.field = uid
-							andWhere = colPos=0
+                            where = ( colPos=0 AND colPos <> '-1')
 						}
 					}
 

--- a/Resources/Public/JavaScript/disableBrowserZooming.js
+++ b/Resources/Public/JavaScript/disableBrowserZooming.js
@@ -3,11 +3,11 @@
  */
 
 /* Blocks browser zooming with keys. (effective after javascript execution) */
-$(document).keydown(function(e) {
+jQuery(document).keydown(function(e) {
 	if(e.ctrlKey && ($.inArray(e.which, [48, 61, 107, 171, 173, 109, 187, 189]) >= 0)) e.preventDefault();
 });
 
 /* Blocks mouse scrolling while STRG or CTRL is held. (effective after javascript execution) */
-$(window).bind('mousewheel DOMMouseScroll', function(e) {
+jQuery(window).on('mousewheel DOMMouseScroll', function(e) {
 	if(e.ctrlKey) e.preventDefault();
 });

--- a/Resources/Public/JavaScript/tgm_reveal.js
+++ b/Resources/Public/JavaScript/tgm_reveal.js
@@ -1,8 +1,7 @@
 /**
  * 2017 - EG (eg@teamgeist-medien.de)
  */
-
-$(document).ready(function() {
+jQuery(function($) {
 	/**
 	 * Stores the reveal-container temporarily, and re-adds it after clearing the body-tag
 	 */
@@ -14,19 +13,19 @@ $(document).ready(function() {
  * Enables Fancybox if required after all images has been loaded
  * TODO: Prevent Fancybox gallery with every image in the presentation (for current slide only).
  */
-$(window).on('load', function() {
-	if($('.reveal').attr('data-enableFancybox') == 'true') {
-		$('img').each(function() {
-			$(this).wrap('<a class="fancybox" rel="fb-group" href="' + $(this).attr('src') + '"></a>');
-		});
-		$('.fancybox').fancybox();
-	}
+jQuery(window).on('load', function() {
+    if(jQuery('.reveal').attr('data-enableFancybox') == 'true') {
+        jQuery('img').each(function() {
+            jQuery(this).wrap('<a class="fancybox" rel="fb-group" href="' + jQuery(this).attr('src') + '"></a>');
+        });
+        jQuery('.fancybox').fancybox();
+    }
 
-	$('body').css('display', 'block');
+    jQuery('body').css('display', 'block');
 });
 
 /**
  * Checks if the url contains the parameter 'print-pdf' and appends the result file to the header.
  */
 var url = 'typo3conf/ext/tgm_reveal/Resources/Public/CSS/' + (window.location.search.match(/print-pdf/gi) ? 'print/pdf.css' : 'print/paper.css');
-$('head').append($('<link rel="stylesheet" type="text/css" href="' + url + '">'));
+jQuery('head').append(jQuery('<link rel="stylesheet" type="text/css" href="' + url + '">'));


### PR DESCRIPTION
He Boys,

nice work but i found 2 Cleanups for you.

## GridElements: 
**Contents will displayed in GE & seperat of it. (Duplicate Content)**
You can fix it by modify: _/ext/tgm_reveal/Configuration/TypoScript/sectionBuilder.ts line: 27_

**From:** 
`andWhere = colPos=0`
**To:** 
`where = ( colPos=0 AND colPos <> '-1')`

## jQuery Error's:
**avoid using $ use jQuery instead:**
**_/ext/tgm_reveal/Resources/Public/JavaScript/disableBrowserZooming.js_**
```
/**
 * 2017 - EG (eg@teamgeist-medien.de)
 */

/* Blocks browser zooming with keys. (effective after javascript execution) */
jQuery(document).keydown(function(e) {
	if(e.ctrlKey && (jQuery.inArray(e.which, [48, 61, 107, 171, 173, 109, 187, 189]) >= 0)) e.preventDefault();
});

/* Blocks mouse scrolling while STRG or CTRL is held. (effective after javascript execution) */
jQuery(window).bind('mousewheel DOMMouseScroll', function(e) {
	if(e.ctrlKey) e.preventDefault();
});
```

**_/ext/tgm_reveal/Resources/Public/JavaScript/tgm_reveal.js_**
```
/**
 * 2017 - EG (eg@teamgeist-medien.de)
 */

jQuery(function($) {
	/**
	 * Stores the reveal-container temporarily, and re-adds it after clearing the body-tag
	 */
	var revealInit = $('.reveal');
	$('body').empty().append(revealInit);
});

/**
 * Enables Fancybox if required after all images has been loaded
 * TODO: Prevent Fancybox gallery with every image in the presentation (for current slide only).
 */
jQuery(window).on('load', function() {
	if(jQuery('.reveal').attr('data-enableFancybox') == 'true') {
        jQuery('img').each(function() {
            jQuery(this).wrap('<a class="fancybox" rel="fb-group" href="' + jQuery(this).attr('src') + '"></a>');
		});
        jQuery('.fancybox').fancybox();
	}

    jQuery('body').css('display', 'block');
});

/**
 * Checks if the url contains the parameter 'print-pdf' and appends the result file to the header.
 */
var url = 'typo3conf/ext/tgm_reveal/Resources/Public/CSS/' + (window.location.search.match(/print-pdf/gi) ? 'print/pdf.css' : 'print/paper.css');
jQuery('head').append(jQuery('<link rel="stylesheet" type="text/css" href="' + url + '">'));
```


Greetings
Dirk Persky
<web kon - Internetagentur>
